### PR TITLE
Clean diagnostics

### DIFF
--- a/lib/asls/diagnostic/parser.ex
+++ b/lib/asls/diagnostic/parser.ex
@@ -95,7 +95,7 @@ defmodule AssemblyScriptLS.Diagnostic.Parser do
     if location?(h) do
       {:ok, [file, line, col], _, _, _, _} = parse_location(h)
 
-      # --- lins and columns are zero-based
+      # --- lines and columns are zero-based
       {
         :ok, 
         [file, String.to_integer(line) - 1, String.to_integer(col) - 1],

--- a/lib/asls/diagnostics.ex
+++ b/lib/asls/diagnostics.ex
@@ -1,2 +1,0 @@
-defmodule AssemblyScriptLS.Diagnostics do
-end

--- a/lib/asls/json_rpc.ex
+++ b/lib/asls/json_rpc.ex
@@ -1,4 +1,9 @@
 defmodule AssemblyScriptLS.JsonRpc do
+  @moduledoc """
+  The AssemblyScriptLS.JsonRpc module implements the JSON RPC protocol.
+  It is the layer between the transport layer (TCP) and the Language Server
+  Specification layer.
+  """
   @state %{socket: nil, transport: nil}
   use GenServer
 
@@ -13,7 +18,6 @@ defmodule AssemblyScriptLS.JsonRpc do
 
   # --- Client API
 
-  # TODO: fix name
   def start_link(opts \\ []) do
     socket = opts[:socket]
     transport = opts[:transport]
@@ -23,11 +27,11 @@ defmodule AssemblyScriptLS.JsonRpc do
     GenServer.start_link(__MODULE__, state, name: name)
   end
 
-  def recv(message) do
+  def recv(message, name \\ __MODULE__) do
     GenServer.call(__MODULE__, {:recv, message})
   end
 
-  def send(message) do
+  def send(message, name \\ __MODULE__) do
     GenServer.call(__MODULE__, {:send, message})
   end
 

--- a/lib/asls/server/build.ex
+++ b/lib/asls/server/build.ex
@@ -1,9 +1,17 @@
 defmodule AssemblyScriptLS.Server.Build do
   alias AssemblyScriptLS.Diagnostic
-  def perform do
+  require Logger
+
+  def perform(root_uri) do
+    task = Task.async(fn -> build(root_uri) end)
+    Logger.debug("Starting build: #{inspect(task.ref)}")
+    task
+  end
+
+  defp build(root_uri) do
     case System.cmd("npm", ["run", "asbuild"], stderr_to_stdout:  true) do
       {content, 1} ->
-        Diagnostic.Parser.parse(content)
+        Diagnostic.Parser.parse(root_uri, content)
       _ ->
         %{}
     end


### PR DESCRIPTION
This change adds the possibility to track the entire diagnostics as part of the server state.

It also tracks if:
- A build is in progress
- If a rebuild is needed
- The opened documents

