### PR TITLE
feat: Improve stdout and stderr initial messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2020-07-19
+
+### Added
+- [TCP] Added initial logging stdout and stderr messages
+
 ## [O.4.0] - 2020-07-03
 
 ### Added

--- a/lib/asls/tcp.ex
+++ b/lib/asls/tcp.ex
@@ -27,18 +27,22 @@ defmodule AssemblyScriptLS.TCP do
   could not be established.
   """
   def start(opts \\ []) do
-    port = Keyword.get(opts, :port) || @port
-    debug = Keyword.get(opts, :debug)
+    port = opts[:port] || @port
+    debug = opts[:debug]
     OK.try do
       socket <- :gen_tcp.listen(port, @opts)
-      socket <- :gen_tcp.accept(socket)
-      _ <- AssemblyScriptLS.start(socket, debug)
     after
-      Logger.debug("Server listening in port #{port}")
-      recv(socket)
+      IO.puts("Server listening @ #{port}")
+      case :gen_tcp.accept(socket) do
+        {:ok, socket} ->
+          AssemblyScriptLS.start(socket, debug)
+          recv(socket)
+        error ->
+          IO.puts(:stderr, "Error occurred while accepting connections @ #{port}. Error: #{inspect(error)}")
+      end
     rescue
       error ->
-        OK.failure(error)
+        IO.puts(:stderr, "Error occurred while listening to connections @ #{port}. Error: #{inspect(error)}")
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -33,5 +33,5 @@ defmodule AssemblyScriptLS.MixProject do
     ]
   end
 
-  defp version, do: "0.4.0"
+  defp version, do: "0.4.1"
 end


### PR DESCRIPTION
This commit adds stdout and stderr initial mesages,
right after the initial connection with the server has
been either accepted or rejected. This is done so that the
client can check the state of the connection request and log
accordingly