### PR TITLE
feat: Dynamic port assignment

### DIFF
--- a/lib/asls/tcp.ex
+++ b/lib/asls/tcp.ex
@@ -31,8 +31,9 @@ defmodule AssemblyScriptLS.TCP do
     debug = opts[:debug]
     OK.try do
       socket <- :gen_tcp.listen(port, @opts)
+      assigned_port <- :inet.port(socket)
     after
-      IO.puts("Server listening @ #{port}")
+      IO.puts("Server listening @ #{assigned_port}")
       case :gen_tcp.accept(socket) do
         {:ok, socket} ->
           AssemblyScriptLS.start(socket, debug)


### PR DESCRIPTION
This commit allows clients to pass 0 as a port number, when this happens
the server will rely on the OS to assign a port to the process.

The assigned process is then retrieved and logged to stdout