### PR TITLE
Improve process comms and server backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- [Server] Improve backpressure and communication mechanism
+
 ## [0.5.1] - 2020-10-10
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: release clean mix zip hash
+.PHONY: release clean mix zip hash test
 
 SHELL := /bin/bash
 MIX_ENV=prod
@@ -22,3 +22,7 @@ zip:
 
 hash:
 	nix-hash --flat --base32 --type sha256 bin.tar.gz
+
+test: MIX_ENV = test
+test:
+	mix test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: release clean mix zip hash test
+.PHONY: release clean mix zip hash test build
 
 SHELL := /bin/bash
 MIX_ENV=prod
@@ -26,3 +26,7 @@ hash:
 test: MIX_ENV = test
 test:
 	mix test
+
+build: MIX_ENV = prod
+build:
+	mix escript.build

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,3 +1,4 @@
 use Mix.Config
 
 config :asls, builder: AssemblyScriptLS.Server.Build
+config :asls, rpc: AssemblyScriptLS.JsonRpc

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :asls, builder: AssemblyScriptLS.Server.Build

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,3 +1,4 @@
 use Mix.Config
 
 config :asls, builder: AssemblyScriptLS.Server.Build
+config :asls, rpc: AssemblyScriptLS.JsonRpc

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :asls, builder: AssemblyScriptLS.Server.Build

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,4 @@
 use Mix.Config
 
-config :asls, builder: AssemblyScriptLS.Server.BuildMock
+config :asls, builder: AssemblyScriptLS.Server.Build.Mock
+config :asls, rpc: AssemblyScriptLS.JsonRpc.Mock

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :asls, builder: AssemblyScriptLS.Server.BuildMock

--- a/lib/asls/json_rpc.ex
+++ b/lib/asls/json_rpc.ex
@@ -4,8 +4,10 @@ defmodule AssemblyScriptLS.JsonRpc do
   It is the layer between the transport layer (TCP) and the Language Server
   Specification layer.
   """
+  @behaviour AssemblyScriptLS.JsonRpc.Behaviour
   @state %{socket: nil, transport: nil}
   use GenServer
+  use OK.Pipe
 
   alias AssemblyScriptLS.Server
   alias AssemblyScriptLS.JsonRpc.Message
@@ -18,6 +20,7 @@ defmodule AssemblyScriptLS.JsonRpc do
 
   # --- Client API
 
+  @impl true
   def start_link(opts \\ []) do
     socket = opts[:socket]
     transport = opts[:transport]
@@ -27,30 +30,33 @@ defmodule AssemblyScriptLS.JsonRpc do
     GenServer.start_link(__MODULE__, state, name: name)
   end
 
-  def recv(message, _name \\ __MODULE__) do
-    GenServer.call(__MODULE__, {:recv, message})
+  @impl true
+  def recv(message, name \\ __MODULE__) do
+    GenServer.call(name, {:recv, message})
   end
 
-  def send(message, _name \\ __MODULE__) do
-    GenServer.call(__MODULE__, {:send, message})
+  @impl true
+  def respond({_type, _id, _payload} = opts, name \\ __MODULE__) do
+    snd(Message.from_attributes(opts), name)
   end
 
-  def respond(type, id, payload) when type in [:error, :result] do
-    opts =
-      Keyword.new([{:id, id}, {type, payload}])
-      |> Enum.into(%{})
+  @impl true
+  def notify(x, y, name \\ __MODULE__)
 
-    send(Message.from_attributes(opts))
-  end
-
-  def notify(type, message) when type in [:error, :warning, :info, :log] do
+  @impl true
+  def notify(type, message, name) when type in [:error, :warning, :info, :log] do
     params = %{type: type, message: message}
     opts = %{method: "window/showMessage", params: params}
-    send(Message.from_attributes(opts))
+    snd(Message.from_attributes(opts), name)
   end
 
-  def notify(method, params) do
-    send(Message.from_attributes(%{method: method, params: params}))
+  @impl true
+  def notify(method, params, name) do
+    snd(Message.from_attributes(%{method: method, params: params}), name)
+  end
+
+  defp snd(message, name) do
+    GenServer.call(name, {:send, message})
   end
 
   # --- Callbacks
@@ -61,14 +67,18 @@ defmodule AssemblyScriptLS.JsonRpc do
   end
 
   @impl true
-  def handle_call({:send, message}, _from, state = %{transport: transport, socket: socket}) do
-    :ok = transport.send(socket, message)
+  def handle_call({:send, message}, _from, state) do
+    :ok = send_through_transport(message, state)
     {:reply, :ok, state}
   end
 
   @impl true
   def handle_call({:recv, %Request{} = req}, _from, state) do
-    Server.handle_request(req)
+    message = 
+      Server.handle_request(req)
+      ~>> Message.from_attributes
+
+    :ok = send_through_transport(message, state)
     {:reply, :ok, state}
   end
 
@@ -89,4 +99,10 @@ defmodule AssemblyScriptLS.JsonRpc do
   end
 
   #TODO: Handle info
+  
+  # --- Helpers
+  
+  defp send_through_transport(message, %{socket: socket, transport: transport}) do
+    transport.send(socket, message)
+  end
 end

--- a/lib/asls/json_rpc/behaviour.ex
+++ b/lib/asls/json_rpc/behaviour.ex
@@ -1,0 +1,14 @@
+defmodule AssemblyScriptLS.JsonRpc.Behaviour do
+  alias AssemblyScriptLS.JsonRpc.Message
+
+  @type options :: Keyword.t()
+  @type notification :: :error | :warning | :info | :log
+
+  @callback start_link(options) :: GenServer.on_start
+  @callback recv(Message.t(), term()) :: :ok
+  @callback respond(Message.t(), term()) :: :ok
+  @callback notify(notification(), String.t()) :: :ok
+  @callback notify(notification(), String.t(), term()) :: :ok
+  @callback notify(String.t(), map()) :: :ok
+  @callback notify(String.t(), map(), term()) :: :ok
+end

--- a/lib/asls/json_rpc/message.ex
+++ b/lib/asls/json_rpc/message.ex
@@ -1,8 +1,10 @@
 defmodule AssemblyScriptLS.JsonRpc.Message do
-  @version "2.0"
   @derive Jason.Encoder
+  @version "2.0"
+  @type t :: Request.t() | Reponse.t() | Notification.t() | Unknown.t()
 
   defmodule Request do
+    @type t :: map()
     @derive Jason.Encoder
     @keys [:jsonrpc, :id, :method, :params]
     @enforce_keys @keys
@@ -11,6 +13,7 @@ defmodule AssemblyScriptLS.JsonRpc.Message do
   end
 
   defmodule Response do
+    @type t :: map()
     @derive Jason.Encoder
     @keys [:jsonrpc, :id, :result, :error]
     @enforce_keys [:jsonrpc, :id]
@@ -19,6 +22,7 @@ defmodule AssemblyScriptLS.JsonRpc.Message do
   end
 
   defmodule Notification do
+    @type t :: map()
     @derive Jason.Encoder
     @keys [:jsonrpc, :method, :params]
     @enforce_keys @keys
@@ -27,11 +31,18 @@ defmodule AssemblyScriptLS.JsonRpc.Message do
   end
 
   defmodule Unknown do
+    @type t :: map()
     defstruct []
   end
 
   def from_attributes(values = %{}) do
     new(Map.merge(%{jsonrpc: @version}, values))
+  end
+  
+  def from_attributes({type, id, payload}) when type in [:error, :result] do
+    Keyword.new([{:id, id}, {type, payload}])
+    |> Enum.into(%{})
+    |> from_attributes
   end
 
   def new(%{jsonrpc: _v, id: _id, method: _method, params: _params} = values) do
@@ -57,4 +68,6 @@ defmodule AssemblyScriptLS.JsonRpc.Message do
   def new(_) do
     struct(Unknown, [])
   end
+
+  def rpc_version, do: @version
 end

--- a/lib/asls/server/build.ex
+++ b/lib/asls/server/build.ex
@@ -1,17 +1,20 @@
 defmodule AssemblyScriptLS.Server.Build do
+  @behaviour AssemblyScriptLS.Server.Job
   alias AssemblyScriptLS.Diagnostic
   require Logger
 
-  def perform(root_uri) do
-    task = Task.async(fn -> build(root_uri) end)
+  @impl true
+  def perform(params) do
+    uri = params[:root_uri]
+    task = Task.async(fn -> build(uri) end)
     Logger.debug("Starting build: #{inspect(task.ref)}")
     task
   end
 
-  defp build(root_uri) do
+  defp build(uri) do
     case System.cmd("npm", ["run", "asbuild"], stderr_to_stdout:  true) do
       {content, 1} ->
-        Diagnostic.Parser.parse(root_uri, content)
+        Diagnostic.Parser.parse(uri, content)
       _ ->
         %{}
     end

--- a/lib/asls/server/job.ex
+++ b/lib/asls/server/job.ex
@@ -1,0 +1,3 @@
+defmodule AssemblyScriptLS.Server.Job do
+  @callback perform(map()) :: Task.t()
+end

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,8 @@ defmodule AssemblyScriptLS.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       escript: escript(),
-      aliases: aliases()
+      aliases: aliases(),
+      elixirc_paths: elixirc_paths(Mix.env)
     ]
   end
 
@@ -23,7 +24,8 @@ defmodule AssemblyScriptLS.MixProject do
     [
       {:nimble_parsec, "~> 0.5"},
       {:ok, "~> 2.3"},
-      {:jason, "~> 1.2"}
+      {:jason, "~> 1.2"},
+      {:mox, "~> 1.0", only: :test}
     ]
   end
 
@@ -41,4 +43,7 @@ defmodule AssemblyScriptLS.MixProject do
   end
 
   defp version, do: "0.5.1"
+
+  defp elixirc_paths(:test), do: ["test/support", "lib"]
+  defp elixirc_paths(_),     do: ["lib"]
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
+  "mox": {:hex, :mox, "1.0.0", "4b3c7005173f47ff30641ba044eb0fe67287743eec9bd9545e37f3002b0a9f8b", [:mix], [], "hexpm", "201b0a20b7abdaaab083e9cf97884950f8a30a1350a1da403b3145e213c6f4df"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
   "ok": {:hex, :ok, "2.3.0", "0a3d513ec9038504dc5359d44e14fc14ef59179e625563a1a144199cdc3a6d30", [:mix], [], "hexpm", "f0347b3f8f115bf347c704184b33cf084f2943771273f2b98a3707a5fa43c4d5"},
 }

--- a/test/asls/server_test.exs
+++ b/test/asls/server_test.exs
@@ -1,0 +1,133 @@
+defmodule AssemblyScriptLS.ServerTest do
+  @process TestServer
+  @root_path "./path"
+  alias AssemblyScriptLS.Server
+  alias AssemblyScriptLS.JsonRpc.Message
+
+  import Mox
+
+  use ExUnit.Case, async: true
+
+  setup do
+    start_supervised!({Server, name: @process})
+    :ok = File.mkdir_p(@root_path)
+
+    set_allowances()
+
+    on_exit(fn -> File.rm_rf!(@root_path) end)
+  end
+
+  def set_allowances do
+    [AssemblyScriptLS.Server.Build.Mock, AssemblyScriptLS.JsonRpc.Mock]
+    |> Enum.each(fn mock -> allow(mock, self(), @process) end)
+  end
+
+  setup :verify_on_exit!
+
+  describe "handle_request/2" do
+    test "on initialize request: initializes the server when the project uri exists" do
+      params = %{rootUri: @root_path}
+      req = Message.new(%{jsonrpc: Message.rpc_version, id: 1, method: "initialize", params: params})
+      {:ok, {type, id, server_info}} = Server.handle_request(req, @process)
+      assert type == :result
+      assert id == 1
+      assert server_info == %{
+        capabilities: %{textDocumentSync: 2},
+        serverInfo: %{name: "AssemblyScript Language Server"},
+      }
+      state = :sys.get_state(@process)
+      assert state[:root_uri] == @root_path
+    end
+
+    test "on initialize request: responds with -32002 when the project uri does not exist" do
+      params = %{rootUri: "./foo"}
+      req = Message.new(%{jsonrpc: Message.rpc_version, id: 1, method: "initialize", params: params})
+      {:ok, {type, id, payload}} = Server.handle_request(req, @process)
+      assert type == :error
+      assert id == 1
+      assert payload == %{
+        code: -32002,
+        message: """
+        Couldn't initialize the server.
+        The project root is invalid or doesn't exist.
+        """
+      }
+      state = :sys.get_state(@process)
+      refute state[:root_uri]
+    end
+  end
+
+  describe "handle_notification/2" do
+    test "on initialized notification: sets the server state to initialized" do
+      notification = Message.new(%{jsonrpc: Message.rpc_version, method: "initialized", params: %{}})
+      :ok = Server.handle_notification(notification, @process)
+      state = :sys.get_state(@process)
+      assert state[:initialized]
+    end
+
+    test "on workspace/didChangeConfiguration notification: performs a build" do
+      AssemblyScriptLS.Server.Build.Mock
+      |> expect(:perform, fn _params -> %{ref: 1} end)
+
+      :ok =
+        Message.new(%{jsonrpc: Message.rpc_version, method: "workspace/didChangeConfiguration", params: %{}})
+        |> Server.handle_notification(@process)
+
+      state = :sys.get_state(@process)
+      assert state.building?
+      refute state.rebuild?
+      assert state.build_ref == 1
+    end
+
+    test "on workspace/didChangeConfiguration notification: enqueues a rebuild if a build is in progress" do
+      :sys.replace_state(@process, fn state -> %{state | building?: true} end)
+      :ok =
+        Message.new(%{jsonrpc: Message.rpc_version, method: "workspace/didChangeConfiguration", params: %{}})
+        |> Server.handle_notification(@process)
+
+      state = :sys.get_state(@process)
+      assert state.building?
+      assert state.rebuild?
+    end
+
+    test "on textDocument/didOpen adds the document to the state" do
+      document = "file://path/to/doc.ts"
+      params = %{textDocument: %{uri: document}}
+      diagnostics = %{uri: document, diagnostics: []}
+
+      AssemblyScriptLS.JsonRpc.Mock
+      |> expect(:notify, fn "textDocument/publishDiagnostics", ^diagnostics -> :ok end)
+
+      :ok =
+        Message.new(%{jsonrpc: Message.rpc_version, method: "textDocument/didOpen", params: params})
+        |> Server.handle_notification(@process)
+
+      state = :sys.get_state(@process)
+      assert document in state.documents
+    end
+
+    test "on textDocument/didSave a rebuild is enqueued if a build is in progress " do
+      :sys.replace_state(@process, fn state -> %{state | building?: true} end)
+      :ok =
+        Message.new(%{jsonrpc: Message.rpc_version, method: "textDocument/didSave", params: %{}})
+        |> Server.handle_notification(@process)
+
+      state = :sys.get_state(@process)
+      assert state.rebuild?
+    end
+
+    test "on textDocument/didSave a build is triggered if no build is in progress" do
+      AssemblyScriptLS.Server.Build.Mock
+      |> expect(:perform, fn _params -> %{ref: 1} end)
+
+      :ok =
+        Message.new(%{jsonrpc: Message.rpc_version, method: "textDocument/didSave", params: %{}})
+        |> Server.handle_notification(@process)
+
+      state = :sys.get_state(@process)
+      assert state.build_ref == 1
+      assert state.building?
+      refute state.rebuild?
+    end
+  end
+end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,1 +1,2 @@
-Mox.defmock(AssemblyScriptLS.Server.BuildMock, for: AssemblyScriptLS.Server.Job)
+Mox.defmock(AssemblyScriptLS.Server.Build.Mock, for: AssemblyScriptLS.Server.Job)
+Mox.defmock(AssemblyScriptLS.JsonRpc.Mock, for: AssemblyScriptLS.JsonRpc.Behaviour)

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,0 +1,1 @@
+Mox.defmock(AssemblyScriptLS.Server.BuildMock, for: AssemblyScriptLS.Server.Job)


### PR DESCRIPTION
This change improves the language server back pressure and improves the communication mechanisms between all the processes. 

The backpressure is improved by either 
- Ack any requests/notifications that need to run async (like builds)
- Inlining any request/notifications that can run in sync

This change also sets the base for unit tests.

This PR prepares the stage incoming changes related to incremental compilation. 